### PR TITLE
#2 ignore files without any coverage lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ __The plugin is available in the [Gradle Plugin Portal](https://plugins.gradle.o
 Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
 ```kotlin
 plugins { 
-    id("dev.turingcomplete.bitbucket-code-coverage") version "1.0.0"
+    id("dev.turingcomplete.bitbucket-code-coverage") version "1.0.1"
 }
 ```
 
@@ -24,7 +24,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("dev.turingcomplete.bitbucket-code-coverage:1.0.0")
+        classpath("dev.turingcomplete.bitbucket-code-coverage:1.0.1")
     }
 }
 
@@ -40,7 +40,7 @@ The following code must be present at least in the `build.gradle.kts` for the pl
 ```kotlin
 plugins {
     jacoco
-    id("dev.turingcomplete.bitbucket-code-coverage") version "1.0.0"
+    id("dev.turingcomplete.bitbucket-code-coverage") version "1.0.1"
 }
 
 bitbucketCodeCoverage {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "dev.turingcomplete"
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
   mavenLocal()
@@ -32,6 +32,11 @@ configure<JavaPluginExtension> {
 
 tasks.getByName<Test>("test") {
   useJUnitPlatform()
+  val tmpDir = File(buildDir, "tmp/test-tmp")
+  systemProperty("java.io.tmpdir", tmpDir)
+  doFirst {
+    tmpDir.mkdirs()
+  }
 }
 
 gradlePlugin {

--- a/src/main/kotlin/dev/turingcomplete/bitbucketcodecoverage/FileCodeCoverage.kt
+++ b/src/main/kotlin/dev/turingcomplete/bitbucketcodecoverage/FileCodeCoverage.kt
@@ -33,6 +33,10 @@ class FileCodeCoverage(val sourceFile: File,
     return "C:${fullyCoveredLines.joinToString(",")};P:${partiallyCoveredLines.joinToString(",")};U:${uncoveredLines.joinToString(",")}"
   }
 
+  fun hasCoverageInfo(): Boolean {
+    return fullyCoveredLines.isNotEmpty() || partiallyCoveredLines.isNotEmpty() || uncoveredLines.isNotEmpty()
+  }
+
   // -- Private Methods --------------------------------------------------------------------------------------------- //
   // -- Inner Type -------------------------------------------------------------------------------------------------- //
 

--- a/src/main/kotlin/dev/turingcomplete/bitbucketcodecoverage/jacoco/PublishJacocoCodeCoverageToBitbucketTask.kt
+++ b/src/main/kotlin/dev/turingcomplete/bitbucketcodecoverage/jacoco/PublishJacocoCodeCoverageToBitbucketTask.kt
@@ -144,7 +144,10 @@ open class PublishJacocoCodeCoverageToBitbucketTask : PublishCodeCoverageToBitbu
 
     fileCodeCoverageBuilderToUnresolvedSourceFile.forEach {
       if (resolvedSourceFiles.containsKey(it.value)) {
-        fileCodeCoverages.add(it.key.build(resolvedSourceFiles[it.value]!!))
+        val coverage = it.key.build(resolvedSourceFiles[it.value]!!)
+        if (coverage.hasCoverageInfo()) {
+          fileCodeCoverages.add(coverage)
+        }
       }
       else {
         missingSourceFiles.add(it.value)

--- a/src/test/java/dev/turingcomplete/gradlebitbucketcodecoverageplugin/PublishCodeCoverageToBitbucketTaskTest.kt
+++ b/src/test/java/dev/turingcomplete/gradlebitbucketcodecoverageplugin/PublishCodeCoverageToBitbucketTaskTest.kt
@@ -119,18 +119,24 @@ class PublishCodeCoverageToBitbucketTaskTest {
   }
 
   @ParameterizedTest
-  @CsvSource(value = ["|||C:;P:;U:", "1|2|3|C:1;P:2;U:3", "1,2|3,4,5|6,7,8,9|C:1,2;P:3,4,5;U:6,7,8,9"], delimiter = '|')
+  @CsvSource(value = [
+    "|||C:;P:;U:|false",
+    "1|2|3|C:1;P:2;U:3|true",
+    "1,2|3,4,5|6,7,8,9|C:1,2;P:3,4,5;U:6,7,8,9|true"
+  ], delimiter = '|')
   fun `Test toBitbucketCodeCoverage`(fullyCoveredLines: String?,
                                      partiallyCoveredLines: String?,
                                      uncoveredCoveredLines: String?,
-                                     expectedBitbucketCoverage: String) {
+                                     expectedBitbucketCoverage: String,
+                                     expectedHasCoverageInfo: Boolean) {
+    val coverage = FileCodeCoverage(
+            File(""),
+            fullyCoveredLines?.split(",")?.map { it.toInt() }?.toSet() ?: emptySet(),
+            partiallyCoveredLines?.split(",")?.map { it.toInt() }?.toSet() ?: emptySet(),
+            uncoveredCoveredLines?.split(",")?.map { it.toInt() }?.toSet() ?: emptySet())
 
-    assertThat(FileCodeCoverage(File(""),
-                                fullyCoveredLines?.split(",")?.map { it.toInt() }?.toSet() ?: emptySet(),
-                                partiallyCoveredLines?.split(",")?.map { it.toInt() }?.toSet() ?: emptySet(),
-                                uncoveredCoveredLines?.split(",")?.map { it.toInt() }?.toSet() ?: emptySet())
-                       .toBitbucketCodeCoverage())
-            .isEqualTo(expectedBitbucketCoverage)
+    assertThat(coverage.toBitbucketCodeCoverage()).isEqualTo(expectedBitbucketCoverage)
+    assertThat(coverage.hasCoverageInfo()).isEqualTo(expectedHasCoverageInfo)
   }
 
   // -- Private Methods --------------------------------------------------------------------------------------------- //

--- a/src/test/java/dev/turingcomplete/gradlebitbucketcodecoverageplugin/jacoco/PublishJacocoCodeCoverageToBitbucketTaskTest.kt
+++ b/src/test/java/dev/turingcomplete/gradlebitbucketcodecoverageplugin/jacoco/PublishJacocoCodeCoverageToBitbucketTaskTest.kt
@@ -57,7 +57,7 @@ class PublishJacocoCodeCoverageToBitbucketTaskTest {
     """.trimIndent())
 
     val result = gradleRunner
-            .withArguments(PublishJacocoCodeCoverageToBitbucketTask.TASK_NAME, "--stacktrace")
+            .withArguments(PublishJacocoCodeCoverageToBitbucketTask.TASK_NAME, "--stacktrace", "--info")
             .forwardOutput()
             .build()
 

--- a/src/test/resources/dev/turingcomplete/gradlebitbucketcodecoverageplugin/testproject/sub-project-1/src/main/java/firstPackage/secondPackage/ClassWithPackage.java
+++ b/src/test/resources/dev/turingcomplete/gradlebitbucketcodecoverageplugin/testproject/sub-project-1/src/main/java/firstPackage/secondPackage/ClassWithPackage.java
@@ -1,6 +1,6 @@
 package firstPackage.secondPackage;
 
-public class ClassWithPackage {
+public class ClassWithPackage implements firstPackage.secondPackage.InterfaceWithoutDefaults {
 
     public static final String STATIC_PARAM = "Static Param";
 

--- a/src/test/resources/dev/turingcomplete/gradlebitbucketcodecoverageplugin/testproject/sub-project-1/src/main/java/firstPackage/secondPackage/InterfaceWithoutDefaults.java
+++ b/src/test/resources/dev/turingcomplete/gradlebitbucketcodecoverageplugin/testproject/sub-project-1/src/main/java/firstPackage/secondPackage/InterfaceWithoutDefaults.java
@@ -1,0 +1,6 @@
+package firstPackage.secondPackage;
+
+public interface InterfaceWithoutDefaults {
+
+    void methodFullyCovered();
+}


### PR DESCRIPTION
Fix for BitBucket error: `Invalid or empty coverage data was supplied for one or more files.`